### PR TITLE
Resolve TS errors in tests

### DIFF
--- a/src/preventTabClose.test.ts
+++ b/src/preventTabClose.test.ts
@@ -28,7 +28,7 @@ describe('preventTabClose', function() {
 		window.dispatchEvent(event);
 
 		assert.ok(preventDefaultSpy.calledOnce);
-		assert.ok(returnValSpy.set.calledWith(''));
+		assert.ok(returnValSpy.set.calledWith('' as any));
 	});
 
 	it('does not cancel beforeunload event when disabled', function() {

--- a/src/test.ts
+++ b/src/test.ts
@@ -2,7 +2,7 @@ import * as jsdom from 'jsdom';
 
 const window = new jsdom.JSDOM('<main></main>').window;
 global.document = window.document;
-global.window = window;
+global.window = window as any;
 global.CustomEvent = window.CustomEvent;
 global.HTMLElement = window.HTMLElement;
 


### PR DESCRIPTION
This PR resolves two TS errors that were reported on build. I wasn't able to find a better solution than casting to `any`, though I'm not a TypeScript expert.

The first issue is that `Event.returnValue` [is a boolean](https://developer.mozilla.org/en-US/docs/Web/API/Event/returnValue) and the test asserts that it is called with a string. However, per MDN, `returnValue` [needs to be set to a string](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event) to prevent tab close in legacy browsers:

> However note that not all browsers support this method, and some instead require the event handler to implement one of two legacy methods:
> - assigning a string to the event's returnValue property

I couldn't figure out how to resolve this type conflict without potentially breaking the action for some browsers, so I cast to any.

The second issue is a mismatch between native DOM window and JSDOM window. I copied the offending lines from the main Svelte project which has a similar linting error in `helpers.ts` (see screenshot below). Wasn't sure how to solve this one either so I slapped an `any` on it for now.

![image](https://user-images.githubusercontent.com/4992896/107102358-2ca78780-67cf-11eb-9619-9d5566ce2163.png)


