### PR TITLE
Invoke callbacks with node as the first parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ Available actions:
 
 ### `clickOutside`
 
-`export function clickOutside(node: HTMLElement, params: {enabled: boolean, cb: Function }): ReturnType<Action>`
+```ts
+export function clickOutside(node: HTMLElement, params: {
+	enabled: boolean, 
+	callback?: (node?: HTMLElement) => void;
+}): ReturnType<Action>
+```
 
 Call callback when user clicks outside a given element.
 
@@ -40,7 +45,7 @@ Demo: https://svelte.dev/repl/dae848c2157e48ab932106779960f5d5?version=3.19.2
 </script>
 
 
-<div use:clickOutside={{ enabled: open, cb: () => open = false }}>
+<div use:clickOutside={{ enabled: open, callback: () => open = false }}>
    <button on:click={() => open = true}>Open</button>
    {#if open}
     <span>
@@ -143,7 +148,7 @@ export function shortcut(node: Action, {
   shift?: boolean;
   alt?: boolean;
   code: string;
-  callback?: () => void;
+  callback?: (node?: HTMLElement) => void;
 })
 ```
 

--- a/src/clickOutside.ts
+++ b/src/clickOutside.ts
@@ -14,7 +14,7 @@ export function clickOutside(node: HTMLElement, params: {enabled: boolean, cb: F
   const { enabled: initialEnabled, cb } = params
 
     const handleOutsideClick = ({ target }: MouseEvent) => {
-      if (!node.contains(target as Node)) cb(); // typescript hack, not sure how to solve without asserting as Node
+      if (!node.contains(target as Node)) cb(node); // typescript hack, not sure how to solve without asserting as Node
     };
 
     function update({enabled}: {enabled: boolean}) {

--- a/src/shortcut.ts
+++ b/src/shortcut.ts
@@ -14,7 +14,7 @@ export type ShortcutSetting = {
 
   code: string;
 
-  callback?: (node: HTMLElement) => void;
+  callback?: (node?: HTMLElement) => void;
 };
 export const shortcut: Action = (node, params: ShortcutSetting | undefined) => {
   let handler: ((e: KeyboardEvent) => void) | undefined;

--- a/src/shortcut.ts
+++ b/src/shortcut.ts
@@ -14,7 +14,7 @@ export type ShortcutSetting = {
 
   code: string;
 
-  callback?: () => void;
+  callback?: (node: HTMLElement) => void;
 };
 export const shortcut: Action = (node, params: ShortcutSetting | undefined) => {
   let handler: ((e: KeyboardEvent) => void) | undefined;
@@ -35,7 +35,7 @@ export const shortcut: Action = (node, params: ShortcutSetting | undefined) => {
 
         e.preventDefault();
 
-        params.callback ? params.callback() : node.click();
+        params.callback ? params.callback(node) : node.click();
       };
       window.addEventListener('keydown', handler);
     };


### PR DESCRIPTION
Allows for an easier way of performing other actions on the element that the action is applied on.

Example use cases:
- Scrolling a div with overflow when a key is pressed.
- Focusing elements that don't respond to clicks (eg. select)

Currently this can be achieved by binding the current node to a variable in the consumer component, and then using that variable in the callback. With this change, the callback will receive the node as a parameter allowing something like
`(node) => node.focus()`