### PR TITLE
Generic action type

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+	require: [
+		'sucrase/register'
+	]
+};

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,5 +1,0 @@
-module.exports = {
-	require: [
-		'sucrase/register'
-	]
-};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+	"useTabs": true,
+	"printWidth": 100,
+	"singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "gh-release": "^4.0.3",
         "jsdom": "^16.4.0",
         "mocha": "^9.2.0",
+        "prettier": "^2.5.1",
         "sinon": "^9.2.3",
         "sucrase": "^3.17.0",
         "svelte": "^3.29.4",
@@ -2901,6 +2902,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -6427,6 +6440,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "type": "module",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --module es2015 --target es5 --outdir dist",
+    "build": "tsc",
     "preversion": "npm run build",
     "version": "auto-changelog -p --template keepachangelog && git add CHANGELOG.md",
     "prepublishOnly": "git push && git push --tags && gh-release",
     "test": "mocha ./src/test.ts",
-    "format": "prettier --write src/**/*.ts"
+    "format": "prettier --write src/**/*.ts",
+    "check": "tsc --noEmit"
   },
   "keywords": [
     "svelte"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preversion": "npm run build",
     "version": "auto-changelog -p --template keepachangelog && git add CHANGELOG.md",
     "prepublishOnly": "git push && git push --tags && gh-release",
-    "test": "mocha ./src/test.ts"
+    "test": "mocha ./src/test.ts",
+    "format": "prettier --write src/**/*.ts"
   },
   "keywords": [
     "svelte"
@@ -41,6 +42,7 @@
     "gh-release": "^4.0.3",
     "jsdom": "^16.4.0",
     "mocha": "^9.2.0",
+    "prettier": "^2.5.1",
     "sinon": "^9.2.3",
     "sucrase": "^3.17.0",
     "svelte": "^3.29.4",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,10 @@
 {
   "name": "svelte-actions",
   "version": "0.2.1",
-  "module": "dist/esm/index.mjs",
-  "main": "dist/index.js",
+  "type": "module",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc && npm run build:esm && npm run rename:esm",
-    "build:esm": "tsc --module es2015 --target es5 --outdir dist/esm",
-    "rename:esm": "find ./dist/esm -name \"*.js\" -exec bash -c 'mv \"$1\" \"${1%.js}\".mjs' - '{}' \\;",
-    "copy:esm": "mv ./dist/esm/*.mjs ./dist/",
+    "build": "tsc --module es2015 --target es5 --outdir dist",
     "preversion": "npm run build",
     "version": "auto-changelog -p --template keepachangelog && git add CHANGELOG.md",
     "prepublishOnly": "git push && git push --tags && gh-release",
@@ -47,5 +43,8 @@
     "sucrase": "^3.17.0",
     "svelte": "^3.29.4",
     "typescript": "^4.0.5"
+  },
+  "exports": {
+    "import": "./dist/index.js"
   }
 }

--- a/src/clickOutside.test.ts
+++ b/src/clickOutside.test.ts
@@ -3,28 +3,28 @@ import { Action } from './types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 
-describe('clickOutside', function() {
+describe('clickOutside', function () {
 	let element: HTMLElement;
 	let sibling: HTMLElement;
 	let action: ReturnType<Action>;
 
-	before(function() {
+	before(function () {
 		element = document.createElement('div');
 		sibling = document.createElement('div');
 		document.body.appendChild(element);
 		document.body.appendChild(sibling);
 	});
 
-	after(function() {
+	after(function () {
 		element.remove();
 		sibling.remove();
 	});
 
-	afterEach(function() {
+	afterEach(function () {
 		action.destroy!();
 	});
 
-	it('calls callback on outside click', function() {
+	it('calls callback on outside click', function () {
 		const cb = sinon.fake();
 		action = clickOutside(element, { enabled: true, cb });
 
@@ -32,7 +32,7 @@ describe('clickOutside', function() {
 		assert.ok(cb.calledOnce);
 	});
 
-	it('does not call callback when disabled', function() {
+	it('does not call callback when disabled', function () {
 		const cb = sinon.fake();
 		action = clickOutside(element, { enabled: false, cb });
 
@@ -40,7 +40,7 @@ describe('clickOutside', function() {
 		assert.ok(cb.notCalled);
 	});
 
-	it('does not call callback when element clicked', function() {
+	it('does not call callback when element clicked', function () {
 		const cb = sinon.fake();
 		action = clickOutside(element, { enabled: true, cb });
 
@@ -48,7 +48,7 @@ describe('clickOutside', function() {
 		assert.ok(cb.notCalled);
 	});
 
-	it('updates parameters', function() {
+	it('updates parameters', function () {
 		const cb = sinon.fake();
 		action = clickOutside(element, { enabled: true, cb });
 

--- a/src/clickOutside.test.ts
+++ b/src/clickOutside.test.ts
@@ -1,12 +1,11 @@
-import { clickOutside } from './clickOutside';
-import { Action } from './types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import { clickOutside } from './clickOutside';
 
 describe('clickOutside', function () {
 	let element: HTMLElement;
 	let sibling: HTMLElement;
-	let action: ReturnType<Action>;
+	let action: ReturnType<typeof clickOutside>;
 
 	before(function () {
 		element = document.createElement('div');
@@ -52,6 +51,7 @@ describe('clickOutside', function () {
 		const cb = sinon.fake();
 		action = clickOutside(element, { enabled: true, cb });
 
+		// @ts-expect-error
 		action.update!({ enabled: false });
 		element.click();
 		assert.ok(cb.notCalled);

--- a/src/clickOutside.ts
+++ b/src/clickOutside.ts
@@ -1,35 +1,37 @@
 import { Action } from './types';
 
 /**
- * 
+ *
  * Call callback when user clicks outside a given element
- * 
+ *
  * Usage:
  * <div use:clickOutside={{ enabled: open, cb: () => open = false }}>
- * 
+ *
  * Demo: https://svelte.dev/repl/dae848c2157e48ab932106779960f5d5?version=3.19.2
- * 
+ *
  */
-export function clickOutside(node: HTMLElement, params: {enabled: boolean, cb: Function }): ReturnType<Action> {
-  const { enabled: initialEnabled, cb } = params
+type Params = { enabled: boolean; cb: (node: HTMLElement) => void };
 
-    const handleOutsideClick = ({ target }: MouseEvent) => {
-      if (!node.contains(target as Node)) cb(node); // typescript hack, not sure how to solve without asserting as Node
-    };
+export const clickOutside: Action<Params> = (node, params) => {
+	const { enabled: initialEnabled, cb } = params;
 
-    function update({enabled}: {enabled: boolean}) {
-      if (enabled) {
-        window.addEventListener('click', handleOutsideClick);
-      } else {
-        window.removeEventListener('click', handleOutsideClick);
-      }
-    }
-    update({ enabled: initialEnabled });
-    return {
-      update,
-      destroy() {
-        window.removeEventListener( 'click', handleOutsideClick );
-      }
-    };
+	const handleOutsideClick = ({ target }: MouseEvent) => {
+		if (!node.contains(target as Node)) cb(node); // typescript hack, not sure how to solve without asserting as Node
+	};
 
-}
+	function update({ enabled }: { enabled: boolean }) {
+		if (enabled) {
+			window.addEventListener('click', handleOutsideClick);
+		} else {
+			window.removeEventListener('click', handleOutsideClick);
+		}
+	}
+
+	update({ enabled: initialEnabled });
+	return {
+		update,
+		destroy() {
+			window.removeEventListener('click', handleOutsideClick);
+		},
+	};
+};

--- a/src/clickOutside.ts
+++ b/src/clickOutside.ts
@@ -13,6 +13,8 @@ import { Action } from './types';
 type Params = { enabled: boolean; cb: (node: HTMLElement) => void };
 
 export const clickOutside: Action<Params> = (node, params) => {
+	if (!params) throw new Error('clickOutside: missing params');
+
 	const { enabled: initialEnabled, cb } = params;
 
 	const handleOutsideClick = ({ target }: MouseEvent) => {

--- a/src/lazyload.test.ts
+++ b/src/lazyload.test.ts
@@ -1,11 +1,10 @@
-import { lazyload } from './lazyload';
-import { Action } from './types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import { lazyload } from './lazyload';
 
 describe('lazyload', function () {
 	let element: HTMLElement;
-	let action: ReturnType<Action>;
+	let action: ReturnType<typeof lazyload>;
 	let intersectionObserverConstructorSpy: sinon.SinonSpy;
 	const observeFake = sinon.fake();
 	const unobserveFake = sinon.fake();

--- a/src/lazyload.test.ts
+++ b/src/lazyload.test.ts
@@ -3,58 +3,62 @@ import { Action } from './types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 
-describe('lazyload', function() {
+describe('lazyload', function () {
 	let element: HTMLElement;
 	let action: ReturnType<Action>;
 	let intersectionObserverConstructorSpy: sinon.SinonSpy;
 	const observeFake = sinon.fake();
 	const unobserveFake = sinon.fake();
 
-	before(function() {
+	before(function () {
 		setupIntersectionObserverMock({
 			observe: observeFake,
-			unobserve: unobserveFake
+			unobserve: unobserveFake,
 		});
 		intersectionObserverConstructorSpy = sinon.spy(global, 'IntersectionObserver');
 	});
 
-	beforeEach(function() {
+	beforeEach(function () {
 		element = document.createElement('div');
 		document.body.appendChild(element);
 	});
 
-	afterEach(function() {
+	afterEach(function () {
 		action.destroy!();
 		element.remove();
 		observeFake.resetHistory();
 		unobserveFake.resetHistory();
 	});
 
-	it('observes node', function() {
+	it('observes node', function () {
 		action = lazyload(element, {});
 		assert.ok(intersectionObserverConstructorSpy.calledOnce);
 		assert.ok(observeFake.calledOnce);
 	});
 
-	it('sets attribute on intersection', function() {
-		action = lazyload(element, { className: 'test'});		
+	it('sets attribute on intersection', function () {
+		action = lazyload(element, { className: 'test' });
 		const intersectionCallback = intersectionObserverConstructorSpy.firstCall.firstArg;
-		intersectionCallback([{ 
-			isIntersecting: true,
-			target: element
-		}]);
+		intersectionCallback([
+			{
+				isIntersecting: true,
+				target: element,
+			},
+		]);
 
 		assert.ok(unobserveFake.calledOnce);
 		assert.strictEqual(element.className, 'test');
 	});
 
-	it('does not set attribute when no intersection', function() {
-		action = lazyload(element, { className: 'test'});		
+	it('does not set attribute when no intersection', function () {
+		action = lazyload(element, { className: 'test' });
 		const intersectionCallback = intersectionObserverConstructorSpy.firstCall.firstArg;
-		intersectionCallback([{ 
-			isIntersecting: false,
-			target: element
-		}]);
+		intersectionCallback([
+			{
+				isIntersecting: false,
+				target: element,
+			},
+		]);
 
 		assert.ok(unobserveFake.notCalled);
 		assert.strictEqual(element.className, '');
@@ -69,7 +73,7 @@ function setupIntersectionObserverMock({
 	disconnect = () => null,
 	observe = () => null,
 	takeRecords = () => [],
-	unobserve = () => null
+	unobserve = () => null,
 } = {}): void {
 	class MockIntersectionObserver implements IntersectionObserver {
 		readonly root: Element | null = root;
@@ -84,12 +88,12 @@ function setupIntersectionObserverMock({
 	Object.defineProperty(window, 'IntersectionObserver', {
 		writable: true,
 		configurable: true,
-		value: MockIntersectionObserver
+		value: MockIntersectionObserver,
 	});
 
 	Object.defineProperty(global, 'IntersectionObserver', {
 		writable: true,
 		configurable: true,
-		value: MockIntersectionObserver
+		value: MockIntersectionObserver,
 	});
 }

--- a/src/lazyload.ts
+++ b/src/lazyload.ts
@@ -1,5 +1,22 @@
 import { Action } from './types';
+const node_attributes_map = new WeakMap<HTMLElement, object>();
 
+const intersection_handler: IntersectionObserverCallback = (entries) => {
+	entries.forEach((entry) => {
+		if (entry.isIntersecting && entry.target instanceof HTMLElement) {
+			const node = entry.target;
+			Object.assign(node, node_attributes_map.get(node));
+			lazy_load_observer.unobserve(node);
+		}
+	});
+};
+
+let lazy_load_observer: IntersectionObserver;
+function observer() {
+	return (
+		lazy_load_observer || (lazy_load_observer = new IntersectionObserver(intersection_handler))
+	);
+}
 /**
  * Attach onto any image to lazy load it
  *
@@ -8,37 +25,12 @@ import { Action } from './types';
  * Demo: https://svelte.dev/repl/f12988de576b4bf9b541a2a59eb838f6?version=3.23.2
  *
  */
-const lazyLoadHandleIntersection: IntersectionObserverCallback = (entries) => {
-	entries.forEach((entry) => {
-		if (!entry.isIntersecting) {
-			return;
-		}
-
-		if (!(entry.target instanceof HTMLElement)) {
-			return;
-		}
-
-		let node = entry.target;
-		let attributes = lazyLoadNodeAttributes.find((item) => item.node === node)?.attributes;
-		Object.assign(node, attributes);
-
-		lazyLoadObserver.unobserve(node);
-	});
-};
-
-let lazyLoadObserver: IntersectionObserver;
-let lazyLoadNodeAttributes: Array<{ node: HTMLElement; attributes: Object }> = [];
-
-export const lazyload: Action<Object> = (node, attributes) => {
-	if (!lazyLoadObserver) {
-		lazyLoadObserver = new IntersectionObserver(lazyLoadHandleIntersection);
-	}
-	lazyLoadNodeAttributes.push({ node, attributes });
-
-	lazyLoadObserver.observe(node);
+export const lazyload: Action<object> = (node, attributes) => {
+	node_attributes_map.set(node, attributes);
+	observer().observe(node);
 	return {
 		destroy() {
-			lazyLoadObserver.unobserve(node);
+			observer().unobserve(node);
 		},
 	};
 };

--- a/src/lazyload.ts
+++ b/src/lazyload.ts
@@ -16,10 +16,11 @@ function observer() {
 	return (lazy_load_observer ??= new IntersectionObserver(intersection_handler));
 }
 /**
- * Attach onto any image to lazy load it
- *
+ * Set attributes on an element when it is visible in the viewport.
+ *@example
+ *```svelte
  * <img use:lazyLoad={{src:"/myimage"}} alt="">
- *
+ *```
  * Demo: https://svelte.dev/repl/f12988de576b4bf9b541a2a59eb838f6?version=3.23.2
  *
  */

--- a/src/lazyload.ts
+++ b/src/lazyload.ts
@@ -1,45 +1,46 @@
-import { Action } from './types';
+import { Action } from "./types";
 
 /**
  * Attach onto any image to lazy load it
- * 
+ *
  * <img use:lazyLoad={{src:"/myimage"}} alt="">
- * 
+ *
  * Demo: https://svelte.dev/repl/f12988de576b4bf9b541a2a59eb838f6?version=3.23.2
- * 
+ *
  */
 const lazyLoadHandleIntersection: IntersectionObserverCallback = (entries) => {
-	entries.forEach(
-		entry => {
-			if (!entry.isIntersecting) {
-				return
-			}
-
-			if (!(entry.target instanceof HTMLElement)) {
-				return;
-			}
-
-			let node = entry.target;
-			let attributes = lazyLoadNodeAttributes.find(item => item.node === node)?.attributes
-			Object.assign(node, attributes)
-
-			lazyLoadObserver.unobserve(node)
+	entries.forEach((entry) => {
+		if (!entry.isIntersecting) {
+			return;
 		}
-	)
-}
+
+		if (!(entry.target instanceof HTMLElement)) {
+			return;
+		}
+
+		let node = entry.target;
+		let attributes = lazyLoadNodeAttributes.find(
+			(item) => item.node === node
+		)?.attributes;
+		Object.assign(node, attributes);
+
+		lazyLoadObserver.unobserve(node);
+	});
+};
 
 let lazyLoadObserver: IntersectionObserver;
-let lazyLoadNodeAttributes: Array<{node: HTMLElement, attributes: Object}> = []
-export function lazyload(node: HTMLElement, attributes: Object): ReturnType<Action> {
+let lazyLoadNodeAttributes: Array<{ node: HTMLElement; attributes: Object }> = [];
+
+export const lazyload: Action<Object> = (node, attributes) => {
 	if (!lazyLoadObserver) {
 		lazyLoadObserver = new IntersectionObserver(lazyLoadHandleIntersection);
 	}
-	lazyLoadNodeAttributes.push({node, attributes})
+	lazyLoadNodeAttributes.push({ node, attributes });
 
 	lazyLoadObserver.observe(node);
 	return {
 		destroy() {
 			lazyLoadObserver.unobserve(node);
-		}
+		},
 	};
-}
+};

--- a/src/lazyload.ts
+++ b/src/lazyload.ts
@@ -27,7 +27,7 @@ const lazyLoadHandleIntersection: IntersectionObserverCallback = (entries) => {
 };
 
 let lazyLoadObserver: IntersectionObserver;
-let lazyLoadNodeAttributes: Array<{ node: HTMLElement; attributes: Object }> = [];
+let lazyLoadNodeAttributes: Array<{ node: HTMLElement; attributes?: Object }> = [];
 
 export const lazyload: Action<Object> = (node, attributes) => {
 	if (!lazyLoadObserver) {

--- a/src/lazyload.ts
+++ b/src/lazyload.ts
@@ -13,9 +13,7 @@ const intersection_handler: IntersectionObserverCallback = (entries) => {
 
 let lazy_load_observer: IntersectionObserver;
 function observer() {
-	return (
-		lazy_load_observer || (lazy_load_observer = new IntersectionObserver(intersection_handler))
-	);
+	return (lazy_load_observer ??= new IntersectionObserver(intersection_handler));
 }
 /**
  * Attach onto any image to lazy load it

--- a/src/lazyload.ts
+++ b/src/lazyload.ts
@@ -27,7 +27,7 @@ const lazyLoadHandleIntersection: IntersectionObserverCallback = (entries) => {
 };
 
 let lazyLoadObserver: IntersectionObserver;
-let lazyLoadNodeAttributes: Array<{ node: HTMLElement; attributes?: Object }> = [];
+let lazyLoadNodeAttributes: Array<{ node: HTMLElement; attributes: Object }> = [];
 
 export const lazyload: Action<Object> = (node, attributes) => {
 	if (!lazyLoadObserver) {

--- a/src/lazyload.ts
+++ b/src/lazyload.ts
@@ -1,4 +1,4 @@
-import { Action } from "./types";
+import { Action } from './types';
 
 /**
  * Attach onto any image to lazy load it
@@ -19,9 +19,7 @@ const lazyLoadHandleIntersection: IntersectionObserverCallback = (entries) => {
 		}
 
 		let node = entry.target;
-		let attributes = lazyLoadNodeAttributes.find(
-			(item) => item.node === node
-		)?.attributes;
+		let attributes = lazyLoadNodeAttributes.find((item) => item.node === node)?.attributes;
 		Object.assign(node, attributes);
 
 		lazyLoadObserver.unobserve(node);

--- a/src/longpress.test.ts
+++ b/src/longpress.test.ts
@@ -1,12 +1,11 @@
-import { longpress } from './longpress';
-import { Action } from './types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import { longpress } from './longpress';
 
 describe('longpress', function () {
 	let element: HTMLElement;
 	let cb = sinon.fake();
-	let action: ReturnType<Action>;
+	let action: ReturnType<typeof longpress>;
 	let clock: sinon.SinonFakeTimers;
 
 	before(function () {

--- a/src/longpress.test.ts
+++ b/src/longpress.test.ts
@@ -3,30 +3,30 @@ import { Action } from './types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 
-describe('longpress', function() {
+describe('longpress', function () {
 	let element: HTMLElement;
 	let cb = sinon.fake();
 	let action: ReturnType<Action>;
 	let clock: sinon.SinonFakeTimers;
 
-	before(function() {
+	before(function () {
 		element = document.createElement('div');
 		element.addEventListener('longpress', cb);
 		document.body.appendChild(element);
 		clock = sinon.useFakeTimers();
 	});
 
-	after(function() {
+	after(function () {
 		element.remove();
 		clock.restore();
 	});
 
-	afterEach(function() {
+	afterEach(function () {
 		action.destroy!();
 		cb.resetHistory();
 	});
 
-	it('dispatches longpress event when mousedown more than duration', function() {
+	it('dispatches longpress event when mousedown more than duration', function () {
 		const duration = 10;
 		action = longpress(element, duration);
 		element.dispatchEvent(new window.MouseEvent('mousedown'));
@@ -35,7 +35,7 @@ describe('longpress', function() {
 		assert.ok(cb.calledOnce);
 	});
 
-	it('does not dispatch longpress event when mousedown less than duration', function() {
+	it('does not dispatch longpress event when mousedown less than duration', function () {
 		action = longpress(element, 100);
 		element.dispatchEvent(new window.MouseEvent('mousedown'));
 		clock.tick(10);
@@ -43,7 +43,7 @@ describe('longpress', function() {
 		assert.ok(cb.notCalled);
 	});
 
-	it('updates duration', function() {
+	it('updates duration', function () {
 		const newDuration = 10;
 		action = longpress(element, 500);
 		action.update!(newDuration);

--- a/src/longpress.ts
+++ b/src/longpress.ts
@@ -1,4 +1,4 @@
-import { Action } from "./types";
+import { Action } from './types';
 
 /**
  * Creates `longpress` event when mousedown above `duration` milliseconds.
@@ -17,7 +17,7 @@ export const longpress: Action<number> = (node, duration) => {
 
 	const handleMousedown = () => {
 		timer = window.setTimeout(() => {
-			node.dispatchEvent(new CustomEvent("longpress"));
+			node.dispatchEvent(new CustomEvent('longpress'));
 		}, duration);
 	};
 
@@ -25,16 +25,16 @@ export const longpress: Action<number> = (node, duration) => {
 		clearTimeout(timer);
 	};
 
-	node.addEventListener("mousedown", handleMousedown);
-	node.addEventListener("mouseup", handleMouseup);
+	node.addEventListener('mousedown', handleMousedown);
+	node.addEventListener('mouseup', handleMouseup);
 
 	return {
 		update(newDuration) {
 			duration = newDuration;
 		},
 		destroy() {
-			node.removeEventListener("mousedown", handleMousedown);
-			node.removeEventListener("mouseup", handleMouseup);
+			node.removeEventListener('mousedown', handleMousedown);
+			node.removeEventListener('mouseup', handleMouseup);
 		},
 	};
 };

--- a/src/longpress.ts
+++ b/src/longpress.ts
@@ -2,14 +2,13 @@ import { Action } from './types';
 
 /**
  * Creates `longpress` event when mousedown above `duration` milliseconds.
- * 
- * Usage:
- * 
- *<button use:longpress={duration}
-    on:longpress="{() => pressed = true}"
-    on:mouseenter="{() => pressed = false}"
-  >press and hold</button>
  *
+ * @example
+ * ```svelte
+ * <button use:longpress={duration} on:longpress={() => alert("longpress")}>
+ * press and hold
+ * </button>
+ *```
  * Demo: https://svelte.dev/tutorial/adding-parameters-to-actions
  */
 export const longpress: Action<number> = (node, duration) => {

--- a/src/longpress.ts
+++ b/src/longpress.ts
@@ -15,26 +15,28 @@ import { Action } from './types';
 export const longpress: Action<number> = (node, duration) => {
 	let timer: number;
 
-	const handleMousedown = () => {
+	function handle_mouse_down() {
 		timer = window.setTimeout(() => {
 			node.dispatchEvent(new CustomEvent('longpress'));
 		}, duration);
-	};
+	}
 
-	const handleMouseup = () => {
+	function handle_mouse_up() {
 		clearTimeout(timer);
-	};
+	}
 
-	node.addEventListener('mousedown', handleMousedown);
-	node.addEventListener('mouseup', handleMouseup);
+	node.addEventListener('mousedown', handle_mouse_down);
+	node.addEventListener('mouseup', handle_mouse_up);
 
 	return {
 		update(newDuration) {
+			handle_mouse_up();
 			duration = newDuration;
 		},
 		destroy() {
-			node.removeEventListener('mousedown', handleMousedown);
-			node.removeEventListener('mouseup', handleMouseup);
+			handle_mouse_up();
+			node.removeEventListener('mousedown', handle_mouse_down);
+			node.removeEventListener('mouseup', handle_mouse_up);
 		},
 	};
 };

--- a/src/longpress.ts
+++ b/src/longpress.ts
@@ -1,4 +1,4 @@
-import { Action } from './types';
+import { Action } from "./types";
 
 /**
  * Creates `longpress` event when mousedown above `duration` milliseconds.
@@ -12,31 +12,29 @@ import { Action } from './types';
  *
  * Demo: https://svelte.dev/tutorial/adding-parameters-to-actions
  */
-export function longpress(node: HTMLElement, duration: number): ReturnType<Action> {
-  let timer: number;
-  
-  const handleMousedown = () => {
-    timer = window.setTimeout(() => {
-      node.dispatchEvent(
-        new CustomEvent('longpress')
-      );
-    }, duration);
-  };
-  
-  const handleMouseup = () => {
-    clearTimeout(timer);
-  };
+export const longpress: Action<number> = (node, duration) => {
+	let timer: number;
 
-  node.addEventListener('mousedown', handleMousedown);
-  node.addEventListener('mouseup', handleMouseup);
+	const handleMousedown = () => {
+		timer = window.setTimeout(() => {
+			node.dispatchEvent(new CustomEvent("longpress"));
+		}, duration);
+	};
 
-  return {
-    update(newDuration) {
-      duration = newDuration;
-    },
-    destroy() {
-      node.removeEventListener('mousedown', handleMousedown);
-      node.removeEventListener('mouseup', handleMouseup);
-    }
-  };
-}
+	const handleMouseup = () => {
+		clearTimeout(timer);
+	};
+
+	node.addEventListener("mousedown", handleMousedown);
+	node.addEventListener("mouseup", handleMouseup);
+
+	return {
+		update(newDuration) {
+			duration = newDuration;
+		},
+		destroy() {
+			node.removeEventListener("mousedown", handleMousedown);
+			node.removeEventListener("mouseup", handleMouseup);
+		},
+	};
+};

--- a/src/pannable.test.ts
+++ b/src/pannable.test.ts
@@ -3,24 +3,24 @@ import { Action } from './types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 
-describe('pannable', function() {
+describe('pannable', function () {
 	let element: HTMLElement;
 	let action: ReturnType<Action>;
 
-	before(function() {
+	before(function () {
 		element = document.createElement('div');
 		document.body.appendChild(element);
 	});
 
-	after(function() {
+	after(function () {
 		element.remove();
 	});
 
-	afterEach(function() {
+	afterEach(function () {
 		action.destroy!();
 	});
 
-	it('dispatches pan events', function() {
+	it('dispatches pan events', function () {
 		action = pannable(element);
 		const panstartCb = sinon.spy();
 		const panmoveCb = sinon.spy();
@@ -29,7 +29,7 @@ describe('pannable', function() {
 		element.addEventListener('panmove', panmoveCb);
 		element.addEventListener('panend', panendCb);
 
-		element.dispatchEvent(new window.MouseEvent('mousedown', { clientX: 20, clientY: 30}));
+		element.dispatchEvent(new window.MouseEvent('mousedown', { clientX: 20, clientY: 30 }));
 		const panstartDetail = panstartCb.firstCall.firstArg.detail;
 		assert.deepStrictEqual(panstartDetail, { x: 20, y: 30 });
 

--- a/src/pannable.test.ts
+++ b/src/pannable.test.ts
@@ -1,11 +1,10 @@
-import { pannable } from './pannable';
-import { Action } from './types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import { pannable } from './pannable';
 
 describe('pannable', function () {
 	let element: HTMLElement;
-	let action: ReturnType<Action>;
+	let action: ReturnType<typeof pannable>;
 
 	before(function () {
 		element = document.createElement('div');

--- a/src/pannable.ts
+++ b/src/pannable.ts
@@ -1,4 +1,4 @@
-import { Action } from "./types";
+import { Action } from './types';
 
 /**
  * Creates panStart, panMove, panEnd events so you can drag elements.
@@ -15,13 +15,13 @@ export const pannable: Action<undefined> = (node: HTMLElement) => {
 		y = event.clientY;
 
 		node.dispatchEvent(
-			new CustomEvent("panstart", {
+			new CustomEvent('panstart', {
 				detail: { x, y },
 			})
 		);
 
-		window.addEventListener("mousemove", handleMousemove);
-		window.addEventListener("mouseup", handleMouseup);
+		window.addEventListener('mousemove', handleMousemove);
+		window.addEventListener('mouseup', handleMouseup);
 	}
 
 	function handleMousemove(event: MouseEvent) {
@@ -31,7 +31,7 @@ export const pannable: Action<undefined> = (node: HTMLElement) => {
 		y = event.clientY;
 
 		node.dispatchEvent(
-			new CustomEvent("panmove", {
+			new CustomEvent('panmove', {
 				detail: { x, y, dx, dy },
 			})
 		);
@@ -42,20 +42,20 @@ export const pannable: Action<undefined> = (node: HTMLElement) => {
 		y = event.clientY;
 
 		node.dispatchEvent(
-			new CustomEvent("panend", {
+			new CustomEvent('panend', {
 				detail: { x, y },
 			})
 		);
 
-		window.removeEventListener("mousemove", handleMousemove);
-		window.removeEventListener("mouseup", handleMouseup);
+		window.removeEventListener('mousemove', handleMousemove);
+		window.removeEventListener('mouseup', handleMouseup);
 	}
 
-	node.addEventListener("mousedown", handleMousedown);
+	node.addEventListener('mousedown', handleMousedown);
 
 	return {
 		destroy() {
-			node.removeEventListener("mousedown", handleMousedown);
+			node.removeEventListener('mousedown', handleMousedown);
 		},
 	};
 };

--- a/src/pannable.ts
+++ b/src/pannable.ts
@@ -5,6 +5,10 @@ import { Action } from './types';
  *
  * Demo: https://svelte.dev/tutorial/actions
  *
+ * @example
+ * ```svelte
+ * <div use:pannable={true} on:panstart on:panmove on:panend>
+ * ```
  */
 export const pannable: Action = (node) => {
 	let x: number;

--- a/src/pannable.ts
+++ b/src/pannable.ts
@@ -6,7 +6,7 @@ import { Action } from './types';
  * Demo: https://svelte.dev/tutorial/actions
  *
  */
-export const pannable: Action = (node: HTMLElement) => {
+export const pannable: Action = (node) => {
 	let x: number;
 	let y: number;
 

--- a/src/pannable.ts
+++ b/src/pannable.ts
@@ -6,7 +6,7 @@ import { Action } from './types';
  * Demo: https://svelte.dev/tutorial/actions
  *
  */
-export const pannable: Action<void> = (node: HTMLElement) => {
+export const pannable: Action = (node: HTMLElement) => {
 	let x: number;
 	let y: number;
 

--- a/src/pannable.ts
+++ b/src/pannable.ts
@@ -1,12 +1,12 @@
-import { Action } from './types';
+import { Action } from "./types";
 
 /**
  * Creates panStart, panMove, panEnd events so you can drag elements.
- * 
+ *
  * Demo: https://svelte.dev/tutorial/actions
- * 
+ *
  */
-export function pannable(node: HTMLElement): ReturnType<Action> {
+export const pannable: Action<undefined> = (node: HTMLElement) => {
 	let x: number;
 	let y: number;
 
@@ -14,12 +14,14 @@ export function pannable(node: HTMLElement): ReturnType<Action> {
 		x = event.clientX;
 		y = event.clientY;
 
-		node.dispatchEvent(new CustomEvent('panstart', {
-			detail: { x, y }
-		}));
+		node.dispatchEvent(
+			new CustomEvent("panstart", {
+				detail: { x, y },
+			})
+		);
 
-		window.addEventListener('mousemove', handleMousemove);
-		window.addEventListener('mouseup', handleMouseup);
+		window.addEventListener("mousemove", handleMousemove);
+		window.addEventListener("mouseup", handleMouseup);
 	}
 
 	function handleMousemove(event: MouseEvent) {
@@ -28,28 +30,32 @@ export function pannable(node: HTMLElement): ReturnType<Action> {
 		x = event.clientX;
 		y = event.clientY;
 
-		node.dispatchEvent(new CustomEvent('panmove', {
-			detail: { x, y, dx, dy }
-		}));
+		node.dispatchEvent(
+			new CustomEvent("panmove", {
+				detail: { x, y, dx, dy },
+			})
+		);
 	}
 
 	function handleMouseup(event: MouseEvent) {
 		x = event.clientX;
 		y = event.clientY;
 
-		node.dispatchEvent(new CustomEvent('panend', {
-			detail: { x, y }
-		}));
+		node.dispatchEvent(
+			new CustomEvent("panend", {
+				detail: { x, y },
+			})
+		);
 
-		window.removeEventListener('mousemove', handleMousemove);
-		window.removeEventListener('mouseup', handleMouseup);
+		window.removeEventListener("mousemove", handleMousemove);
+		window.removeEventListener("mouseup", handleMouseup);
 	}
 
-	node.addEventListener('mousedown', handleMousedown);
+	node.addEventListener("mousedown", handleMousedown);
 
 	return {
 		destroy() {
-			node.removeEventListener('mousedown', handleMousedown);
-		}
+			node.removeEventListener("mousedown", handleMousedown);
+		},
 	};
-}
+};

--- a/src/pannable.ts
+++ b/src/pannable.ts
@@ -10,7 +10,7 @@ export const pannable: Action = (node) => {
 	let x: number;
 	let y: number;
 
-	function handleMousedown(event: MouseEvent) {
+	function handle_mousedown(event: MouseEvent) {
 		x = event.clientX;
 		y = event.clientY;
 
@@ -20,11 +20,11 @@ export const pannable: Action = (node) => {
 			})
 		);
 
-		window.addEventListener('mousemove', handleMousemove);
-		window.addEventListener('mouseup', handleMouseup);
+		window.addEventListener('mousemove', handle_mousemove);
+		window.addEventListener('mouseup', handle_mouseup);
 	}
 
-	function handleMousemove(event: MouseEvent) {
+	function handle_mousemove(event: MouseEvent) {
 		const dx = event.clientX - x;
 		const dy = event.clientY - y;
 		x = event.clientX;
@@ -37,7 +37,7 @@ export const pannable: Action = (node) => {
 		);
 	}
 
-	function handleMouseup(event: MouseEvent) {
+	function handle_mouseup(event: MouseEvent) {
 		x = event.clientX;
 		y = event.clientY;
 
@@ -47,15 +47,15 @@ export const pannable: Action = (node) => {
 			})
 		);
 
-		window.removeEventListener('mousemove', handleMousemove);
-		window.removeEventListener('mouseup', handleMouseup);
+		window.removeEventListener('mousemove', handle_mousemove);
+		window.removeEventListener('mouseup', handle_mouseup);
 	}
 
-	node.addEventListener('mousedown', handleMousedown);
+	node.addEventListener('mousedown', handle_mousedown);
 
 	return {
 		destroy() {
-			node.removeEventListener('mousedown', handleMousedown);
+			node.removeEventListener('mousedown', handle_mousedown);
 		},
 	};
 };

--- a/src/pannable.ts
+++ b/src/pannable.ts
@@ -6,7 +6,7 @@ import { Action } from './types';
  * Demo: https://svelte.dev/tutorial/actions
  *
  */
-export const pannable: Action<undefined> = (node: HTMLElement) => {
+export const pannable: Action<void> = (node: HTMLElement) => {
 	let x: number;
 	let y: number;
 

--- a/src/preventTabClose.test.ts
+++ b/src/preventTabClose.test.ts
@@ -1,11 +1,10 @@
 import { preventTabClose } from './preventTabClose';
-import { Action } from './types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 
 describe('preventTabClose', function () {
 	let element: HTMLElement;
-	let action: ReturnType<Action>;
+	let action: ReturnType<typeof preventTabClose>;
 
 	before(function () {
 		element = document.createElement('div');

--- a/src/preventTabClose.test.ts
+++ b/src/preventTabClose.test.ts
@@ -3,24 +3,24 @@ import { Action } from './types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 
-describe('preventTabClose', function() {
+describe('preventTabClose', function () {
 	let element: HTMLElement;
 	let action: ReturnType<Action>;
 
-	before(function() {
+	before(function () {
 		element = document.createElement('div');
 		document.body.appendChild(element);
 	});
 
-	after(function() {
+	after(function () {
 		element.remove();
 	});
 
-	afterEach(function() {
+	afterEach(function () {
 		action.destroy!();
 	});
 
-	it('cancels beforeunload event when enabled', function() {
+	it('cancels beforeunload event when enabled', function () {
 		action = preventTabClose(element, true);
 		const event = new window.Event('beforeunload');
 		const preventDefaultSpy = sinon.spy(event, 'preventDefault');
@@ -31,7 +31,7 @@ describe('preventTabClose', function() {
 		assert.ok(returnValSpy.set.calledWith('' as any));
 	});
 
-	it('does not cancel beforeunload event when disabled', function() {
+	it('does not cancel beforeunload event when disabled', function () {
 		action = preventTabClose(element, false);
 		const event = new window.Event('beforeunload');
 		const preventDefaultSpy = sinon.spy(event, 'preventDefault');
@@ -40,7 +40,7 @@ describe('preventTabClose', function() {
 		assert.ok(preventDefaultSpy.notCalled);
 	});
 
-	it('updates enabled parameter', function() {
+	it('updates enabled parameter', function () {
 		action = preventTabClose(element, false);
 		const event = new window.Event('beforeunload');
 		const preventDefaultSpy = sinon.spy(event, 'preventDefault');

--- a/src/preventTabClose.ts
+++ b/src/preventTabClose.ts
@@ -1,4 +1,4 @@
-import { Action } from "./types";
+import { Action } from './types';
 
 /**
  * Prevent current tab from being closed by user
@@ -8,12 +8,12 @@ import { Action } from "./types";
 export const preventTabClose: Action<boolean> = (_, enabled) => {
 	const handler = (e: BeforeUnloadEvent) => {
 			e.preventDefault();
-			e.returnValue = "";
+			e.returnValue = '';
 		},
 		setHandler = (shouldWork: boolean) =>
 			shouldWork
-				? window.addEventListener("beforeunload", handler)
-				: window.removeEventListener("beforeunload", handler);
+				? window.addEventListener('beforeunload', handler)
+				: window.removeEventListener('beforeunload', handler);
 
 	setHandler(enabled);
 

--- a/src/preventTabClose.ts
+++ b/src/preventTabClose.ts
@@ -5,20 +5,22 @@ import { Action } from './types';
  *
  * Demo: https://svelte.dev/repl/a95db12c1b46433baac2817a0963dc93
  */
-export const preventTabClose: Action<boolean> = (_, enabled = false) => {
-	const handler = (e: BeforeUnloadEvent) => {
-			e.preventDefault();
-			e.returnValue = '';
-		},
-		setHandler = (shouldWork: boolean) =>
-			shouldWork
-				? window.addEventListener('beforeunload', handler)
-				: window.removeEventListener('beforeunload', handler);
+export const preventTabClose: Action<boolean> = (_, enabled: boolean) => {
+	function handler(e: BeforeUnloadEvent) {
+		e.preventDefault();
+		e.returnValue = '';
+	}
 
-	setHandler(enabled);
+	function set_handler(shouldWork: boolean) {
+		(shouldWork ? window.addEventListener : window.removeEventListener)('beforeunload', handler);
+	}
+
+	set_handler(enabled);
 
 	return {
-		update: setHandler,
-		destroy: () => setHandler(false),
+		update: set_handler,
+		destroy() {
+			set_handler(false);
+		},
 	};
 };

--- a/src/preventTabClose.ts
+++ b/src/preventTabClose.ts
@@ -5,7 +5,7 @@ import { Action } from './types';
  *
  * Demo: https://svelte.dev/repl/a95db12c1b46433baac2817a0963dc93
  */
-export const preventTabClose: Action<boolean> = (_, enabled) => {
+export const preventTabClose: Action<boolean> = (_, enabled = false) => {
 	const handler = (e: BeforeUnloadEvent) => {
 			e.preventDefault();
 			e.returnValue = '';

--- a/src/preventTabClose.ts
+++ b/src/preventTabClose.ts
@@ -4,6 +4,11 @@ import { Action } from './types';
  * Prevent current tab from being closed by user
  *
  * Demo: https://svelte.dev/repl/a95db12c1b46433baac2817a0963dc93
+ *
+ * @example
+ * ```svelte
+ * <div use:preventTabClose={true}>
+ * ```
  */
 export const preventTabClose: Action<boolean> = (_, enabled: boolean) => {
 	function handler(e: BeforeUnloadEvent) {

--- a/src/preventTabClose.ts
+++ b/src/preventTabClose.ts
@@ -1,24 +1,24 @@
-import { Action } from './types';
+import { Action } from "./types";
 
 /**
  * Prevent current tab from being closed by user
- * 
+ *
  * Demo: https://svelte.dev/repl/a95db12c1b46433baac2817a0963dc93
  */
-export const preventTabClose: Action = (_, enabled: boolean) => {
-  const handler = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      e.returnValue = '';
-    },
-    setHandler = (shouldWork: boolean) =>
-      shouldWork ?
-        window.addEventListener('beforeunload', handler) :
-        window.removeEventListener('beforeunload', handler);
+export const preventTabClose: Action<boolean> = (_, enabled) => {
+	const handler = (e: BeforeUnloadEvent) => {
+			e.preventDefault();
+			e.returnValue = "";
+		},
+		setHandler = (shouldWork: boolean) =>
+			shouldWork
+				? window.addEventListener("beforeunload", handler)
+				: window.removeEventListener("beforeunload", handler);
 
-  setHandler(enabled);
+	setHandler(enabled);
 
-  return {
-    update: setHandler,
-    destroy: () => setHandler(false),
-  };
+	return {
+		update: setHandler,
+		destroy: () => setHandler(false),
+	};
 };

--- a/src/shortcut.test.ts
+++ b/src/shortcut.test.ts
@@ -1,11 +1,11 @@
-import { shortcut } from './shortcut';
-import { Action } from './types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import { shortcut } from './shortcut';
+
 
 describe('shortcut', function () {
 	let element: HTMLElement;
-	let action: ReturnType<Action>;
+	let action: ReturnType<typeof shortcut>;
 
 	const spaceKeyCode = 'Space';
 

--- a/src/shortcut.test.ts
+++ b/src/shortcut.test.ts
@@ -3,26 +3,26 @@ import { Action } from './types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 
-describe('shortcut', function() {
+describe('shortcut', function () {
 	let element: HTMLElement;
 	let action: ReturnType<Action>;
 
 	const spaceKeyCode = 'Space';
 
-	before(function() {
+	before(function () {
 		element = document.createElement('div');
 		document.body.appendChild(element);
 	});
 
-	after(function() {
+	after(function () {
 		element.remove();
 	});
 
-	afterEach(function() {
+	afterEach(function () {
 		action.destroy!();
 	});
 
-	it('calls callback when callback provided', function() {
+	it('calls callback when callback provided', function () {
 		const callback = sinon.fake();
 		action = shortcut(element, { code: spaceKeyCode, callback });
 		dispatchKeydownEvent({ code: spaceKeyCode });
@@ -30,7 +30,7 @@ describe('shortcut', function() {
 		assert.ok(callback.calledOnce);
 	});
 
-	it('clicks node when callback not provided', function() {
+	it('clicks node when callback not provided', function () {
 		const callback = sinon.fake();
 		action = shortcut(element, { code: spaceKeyCode });
 		element.addEventListener('click', callback);
@@ -40,7 +40,7 @@ describe('shortcut', function() {
 		element.removeEventListener('click', callback);
 	});
 
-	it('does not call callback when different key pressed', function() {
+	it('does not call callback when different key pressed', function () {
 		const callback = sinon.fake();
 		action = shortcut(element, { code: spaceKeyCode, callback });
 		dispatchKeydownEvent({ code: 'KeyA' });
@@ -48,7 +48,7 @@ describe('shortcut', function() {
 		assert.ok(callback.notCalled);
 	});
 
-	it('handles alt key', function() {
+	it('handles alt key', function () {
 		const callback = sinon.fake();
 		action = shortcut(element, { code: spaceKeyCode, callback, alt: true });
 		dispatchKeydownEvent({ code: spaceKeyCode, altKey: true });
@@ -56,7 +56,7 @@ describe('shortcut', function() {
 		assert.ok(callback.calledOnce);
 	});
 
-	it('handles shift key', function() {
+	it('handles shift key', function () {
 		const callback = sinon.fake();
 		action = shortcut(element, { code: spaceKeyCode, callback, shift: true });
 		dispatchKeydownEvent({ code: spaceKeyCode, shiftKey: true });
@@ -64,7 +64,7 @@ describe('shortcut', function() {
 		assert.ok(callback.calledOnce);
 	});
 
-	it('handles ctrl and meta key', function() {
+	it('handles ctrl and meta key', function () {
 		const callback = sinon.fake();
 		action = shortcut(element, { code: spaceKeyCode, callback, control: true });
 		dispatchKeydownEvent({ code: spaceKeyCode, ctrlKey: true });
@@ -73,7 +73,7 @@ describe('shortcut', function() {
 		assert.ok(callback.calledTwice);
 	});
 
-	it('updates key code', function() {
+	it('updates key code', function () {
 		const callback = sinon.fake();
 		action = shortcut(element, { code: spaceKeyCode, callback });
 		action.update!({ code: 'KeyA', callback });
@@ -81,7 +81,7 @@ describe('shortcut', function() {
 		dispatchKeydownEvent({ code: spaceKeyCode });
 
 		assert.ok(callback.calledOnce);
-	});	
+	});
 });
 
 function dispatchKeydownEvent(eventInitDict: KeyboardEventInit) {

--- a/src/shortcut.test.ts
+++ b/src/shortcut.test.ts
@@ -2,7 +2,6 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { shortcut } from './shortcut';
 
-
 describe('shortcut', function () {
 	let element: HTMLElement;
 	let action: ReturnType<typeof shortcut>;

--- a/src/shortcut.ts
+++ b/src/shortcut.ts
@@ -13,30 +13,30 @@ export type ShortcutSetting = {
 	alt?: boolean;
 
 	code: string;
-
-	callback?: (node?: HTMLElement) => void;
+	enabled?: boolean;
+	callback?: (node: HTMLElement) => void;
 };
 export const shortcut: Action<ShortcutSetting> = (node, params) => {
 	let handler: ((e: KeyboardEvent) => void) | undefined;
 
 	const removeHandler = () => window.removeEventListener('keydown', handler!);
 
-	const setHandler = (params: ShortcutSetting) => {
+	const setHandler = (_params: typeof params) => {
 		removeHandler();
-		if (!params) return;
 
 		handler = (e: KeyboardEvent) => {
 			if (
-				!!params.alt != e.altKey ||
-				!!params.shift != e.shiftKey ||
-				!!params.control != (e.ctrlKey || e.metaKey) ||
-				params.code != e.code
+				!_params?.enabled ||
+				!!_params.alt != e.altKey ||
+				!!_params.shift != e.shiftKey ||
+				!!_params.control != (e.ctrlKey || e.metaKey) ||
+				_params.code != e.code
 			)
 				return;
 
 			e.preventDefault();
 
-			params.callback ? params.callback(node) : node.click();
+			_params.callback ? _params.callback(node) : node.click();
 		};
 		window.addEventListener('keydown', handler);
 	};

--- a/src/shortcut.ts
+++ b/src/shortcut.ts
@@ -1,4 +1,4 @@
-import { Action } from "./types";
+import { Action } from './types';
 
 /**
  * Simplest possible way to add a keyboard shortcut to a div or a button.
@@ -19,7 +19,7 @@ export type ShortcutSetting = {
 export const shortcut: Action<ShortcutSetting | undefined> = (node, params) => {
 	let handler: ((e: KeyboardEvent) => void) | undefined;
 
-	const removeHandler = () => window.removeEventListener("keydown", handler!);
+	const removeHandler = () => window.removeEventListener('keydown', handler!);
 
 	const setHandler = (params: ShortcutSetting | undefined) => {
 		removeHandler();
@@ -38,7 +38,7 @@ export const shortcut: Action<ShortcutSetting | undefined> = (node, params) => {
 
 			params.callback ? params.callback(node) : node.click();
 		};
-		window.addEventListener("keydown", handler);
+		window.addEventListener('keydown', handler);
 	};
 
 	setHandler(params);

--- a/src/shortcut.ts
+++ b/src/shortcut.ts
@@ -16,12 +16,12 @@ export type ShortcutSetting = {
 
 	callback?: (node?: HTMLElement) => void;
 };
-export const shortcut: Action<ShortcutSetting | undefined> = (node, params) => {
+export const shortcut: Action<ShortcutSetting> = (node, params) => {
 	let handler: ((e: KeyboardEvent) => void) | undefined;
 
 	const removeHandler = () => window.removeEventListener('keydown', handler!);
 
-	const setHandler = (params: ShortcutSetting | undefined) => {
+	const setHandler = (params: ShortcutSetting) => {
 		removeHandler();
 		if (!params) return;
 

--- a/src/shortcut.ts
+++ b/src/shortcut.ts
@@ -1,50 +1,58 @@
-import { Action } from './types';
+import type { Action } from './types.js';
 
-/**
- * Simplest possible way to add a keyboard shortcut to a div or a button.
- * It either calls a callback or clicks on the node it was put on.
- *
- * Demo: https://svelte.dev/repl/acd92c9726634ec7b3d8f5f759824d15
- */
+export type ShortcutConfig = {
+	/**
+	 * The code of the key to listen for.
+	 * {@link https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code}
+	 */
+	code: KeyboardEventInit['code'];
 
-export type ShortcutSetting = {
+	/**
+	 * The callback to be called when the shortcut is triggered.
+	 */
+	callback?: (node: HTMLElement) => void;
+
 	control?: boolean;
 	shift?: boolean;
 	alt?: boolean;
-
-	code: string;
-	enabled?: boolean;
-	callback?: (node: HTMLElement) => void;
 };
-export const shortcut: Action<ShortcutSetting> = (node, params) => {
-	let handler: ((e: KeyboardEvent) => void) | undefined;
 
-	const removeHandler = () => window.removeEventListener('keydown', handler!);
+function default_callback(node: HTMLElement) {
+	node.click();
+}
+/**
+ * Simplest possible way to add a keyboard shortcut to an element.
+ * It either calls a callback or clicks on the node it was put on.
+ *
+ * @example
+ * ```svelte
+ * <div use:shortcut={{ code: 'KeyA', callback: () => alert('A') }}>
+ * ```
+ */
+export const shortcut: Action<ShortcutConfig> = (node, config) => {
+	function handler(event: KeyboardEvent) {
+		const should_ignore = !(
+			!!config.alt == event.altKey &&
+			!!config.shift == event.shiftKey &&
+			!!config.control == (event.ctrlKey || event.metaKey) &&
+			config.code == event.code
+		);
 
-	const setHandler = (_params: typeof params) => {
-		removeHandler();
+		if (should_ignore) return;
 
-		handler = (e: KeyboardEvent) => {
-			if (
-				!_params?.enabled ||
-				!!_params.alt != e.altKey ||
-				!!_params.shift != e.shiftKey ||
-				!!_params.control != (e.ctrlKey || e.metaKey) ||
-				_params.code != e.code
-			)
-				return;
+		event.preventDefault();
 
-			e.preventDefault();
+		(config.callback || default_callback)(node);
+	}
 
-			_params.callback ? _params.callback(node) : node.click();
-		};
-		window.addEventListener('keydown', handler);
-	};
-
-	setHandler(params);
+	window.addEventListener('keydown', handler);
 
 	return {
-		update: setHandler,
-		destroy: removeHandler,
+		update(params) {
+			config = params;
+		},
+		destroy() {
+			window.removeEventListener('keydown', handler);
+		},
 	};
 };

--- a/src/shortcut.ts
+++ b/src/shortcut.ts
@@ -1,49 +1,50 @@
-import { Action } from './types';
+import { Action } from "./types";
 
 /**
  * Simplest possible way to add a keyboard shortcut to a div or a button.
  * It either calls a callback or clicks on the node it was put on.
- * 
+ *
  * Demo: https://svelte.dev/repl/acd92c9726634ec7b3d8f5f759824d15
  */
 
 export type ShortcutSetting = {
-  control?: boolean;
-  shift?: boolean;
-  alt?: boolean;
+	control?: boolean;
+	shift?: boolean;
+	alt?: boolean;
 
-  code: string;
+	code: string;
 
-  callback?: (node?: HTMLElement) => void;
+	callback?: (node?: HTMLElement) => void;
 };
-export const shortcut: Action = (node, params: ShortcutSetting | undefined) => {
-  let handler: ((e: KeyboardEvent) => void) | undefined;
+export const shortcut: Action<ShortcutSetting | undefined> = (node, params) => {
+	let handler: ((e: KeyboardEvent) => void) | undefined;
 
-  const removeHandler = () => window.removeEventListener('keydown', handler!),
-    setHandler = (params: ShortcutSetting | undefined) => {
-      removeHandler();
-      if (!params) return;
+	const removeHandler = () => window.removeEventListener("keydown", handler!);
 
-      handler = (e: KeyboardEvent) => {
-        if (
-          (!!params.alt != e.altKey) ||
-          (!!params.shift != e.shiftKey) ||
-          (!!params.control != (e.ctrlKey || e.metaKey)) ||
-          params.code != e.code
-        )
-          return;
+	const setHandler = (params: ShortcutSetting | undefined) => {
+		removeHandler();
+		if (!params) return;
 
-        e.preventDefault();
+		handler = (e: KeyboardEvent) => {
+			if (
+				!!params.alt != e.altKey ||
+				!!params.shift != e.shiftKey ||
+				!!params.control != (e.ctrlKey || e.metaKey) ||
+				params.code != e.code
+			)
+				return;
 
-        params.callback ? params.callback(node) : node.click();
-      };
-      window.addEventListener('keydown', handler);
-    };
+			e.preventDefault();
 
-  setHandler(params);
+			params.callback ? params.callback(node) : node.click();
+		};
+		window.addEventListener("keydown", handler);
+	};
 
-  return {
-    update: setHandler,
-    destroy: removeHandler,
-  };
+	setHandler(params);
+
+	return {
+		update: setHandler,
+		destroy: removeHandler,
+	};
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,7 @@
-export type Action = (node: HTMLElement, parameters: any) => {
-	update?: (parameters: any) => void,
-	destroy?: () => void
-}
+export type Action<Params = any> = (
+	node: HTMLElement,
+	parameters: Params
+) => {
+	update?: (parameters: Params) => void;
+	destroy?: () => void;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,8 @@
-export interface ActionReturn<Parameter = any> {
+export interface ActionReturn<Parameter = void> {
 	update?: (parameter: Parameter) => void;
 	destroy?: () => void;
 }
 
-export interface Action<Parameter = any> {
-	<Node extends HTMLElement>(node: Node, parameter?: Parameter): void | ActionReturn<Parameter>;
+export interface Action<Parameter = void> {
+	<Node extends HTMLElement>(node: Node, parameter: Parameter): ActionReturn<Parameter>;
 }
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
-export interface ActionReturn<Parameter = void> {
+export interface ActionReturn<Parameter> {
 	update?: (parameter: Parameter) => void;
 	destroy?: () => void;
 }
 
-export interface Action<Parameter = void> {
-	<Node extends HTMLElement>(node: Node, parameter: Parameter): ActionReturn<Parameter>;
+export interface Action<Parameter = void, Return = ActionReturn<Parameter>> {
+	<Node extends HTMLElement>(node: Node, parameter: Parameter): Return;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,9 @@
-export type Action<Params = any> = (
-	node: HTMLElement,
-	parameters: Params
-) => {
-	update?: (parameters: Params) => void;
+export interface ActionReturn<Parameter = any> {
+	update?: (parameter: Parameter) => void;
 	destroy?: () => void;
-};
+}
+
+export interface Action<Parameter = any> {
+	<Node extends HTMLElement>(node: Node, parameter?: Parameter): void | ActionReturn<Parameter>;
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,5 +65,9 @@
     /* Advanced Options */
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "**/*test.ts"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "module": "ES2015",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "lib": ["esnext", "dom"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
The shortcut action being typed as `Action` was getting rid of type hints in the distributed package because the second argument ended up as `any`. This should help fix that.

Meant to just fix that type error but got a bit carried away (oops). So there are a few big changes.
1. The types are fixed and consistent across the actions using a generic.
2. Added prettier because formatting was inconsistent across the files.
3. As this was intended to be included in svelte, figured might as well follow the conventions there, so I switched some internal identifiers to use snake_case.
4. Ditched CJS build, because pretty much all svelte apps use ES modules or are backed by a build tool that supports it.
5. Excluded test files so that they don't end up in the dist folder.
---
CI is failing because Node 14 doesn't understand the `??=` operator but it should be fine in dist because tsc compiles that away to ES5. The tests are passing on v15+ but got cancelled.