### PR TITLE
feat: refactor & implement `active` prop

### DIFF
--- a/src/shortcut.test.ts
+++ b/src/shortcut.test.ts
@@ -81,6 +81,18 @@ describe('shortcut', function () {
 
 		assert.ok(callback.calledOnce);
 	});
+
+	it('does not fire callback when it is inactive', function () {
+		const callback = sinon.fake();
+		action = shortcut(element, { code: spaceKeyCode, callback });
+		dispatchKeydownEvent({ code: spaceKeyCode });
+		action.update!({ active: false, code: spaceKeyCode, callback });
+		dispatchKeydownEvent({ code: spaceKeyCode });
+		action.update!({ code: spaceKeyCode, callback });
+		dispatchKeydownEvent({ code: spaceKeyCode });
+
+		assert.ok(callback.calledTwice);
+	});
 });
 
 function dispatchKeydownEvent(eventInitDict: KeyboardEventInit) {


### PR DESCRIPTION
- Refactor the action a bit, the `shouldIgnore` looked a bit unreadable;
- Implement `active` property to toggle listener when needed. For example, the action might be used to close the Modal on `Escape` key and the listener will be active when the Modal is closed;
- Implemented a test case for `active` property;

All tests are passed.